### PR TITLE
Modified a single source file, decetable6.cpp

### DIFF
--- a/source/decetable6.cpp
+++ b/source/decetable6.cpp
@@ -241,7 +241,7 @@ int DeceTableMF6Law7(ENDF *lib6, int idx)
 
       double mu  = lib6->rdata[idx].c2;
       int    nrp = lib6->rdata[idx].n1;
-      int    nep = lib6->rdata[idx].n2; idx++;
+      int    nep = lib6->rdata[idx].n2;
 
       cout << "#          NRP" << setw(14) << nrp << "  NR for secondary energy" << endl;
       cout << "#          NEP" << setw(14) << nep << "  number of secondary energy points" << endl;
@@ -251,7 +251,7 @@ int DeceTableMF6Law7(ENDF *lib6, int idx)
         outVal(lib6->xptr[idx][2*i2  ]);
         outVal(lib6->xptr[idx][2*i2+1]);
         cout << endl;
-      }
+      } idx++;
       cout << endl;
     }
     cout << endl;


### PR DESCRIPTION
Corrected the increment of variable idx; it was being incremented
before the innermost loop, corresponding to the secondary particle
energy, was being printed. This means that the next idx energy/cross
section values were being printed next to the current angle.

Moving the idx++ after calls to outVal in the i2=0 to nep-1 loop fixes
it.