### PR TITLE
Contribution from CP2020 L2 Milestone project: incident CP can have v…

### DIFF
--- a/source/endflib.cpp
+++ b/source/endflib.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <sstream>
 #include <cmath>
+#include <limits>
 
 using namespace std;
 
@@ -1287,13 +1288,23 @@ void ENDFMF2boundary(ENDFDict *dict, ENDF *lib)
 /**********************************************************/
 inline void ENDFDelExp(double x, char *num)
 {
+  double min_val = numeric_limits<double>::min();
   ostringstream os;
   os.setf(ios::scientific, ios::floatfield);
 
   double z = fabs(x);
   /*** too small numbers will be rounded to zero */
-  if(z < 1.0e-99){
+  if(z < min_val){
     strcpy(num," 0.000000+0");
+  }
+  /*** when the negative exponent has 3 digits */
+  else if(z <= 1.0e-99){
+    os << setprecision(4) << setw(12) << x;
+    string s = os.str();
+    strcpy(num,s.c_str());
+    for(int i=7 ; i<=10 ; i++) num[i] = num[i+1];
+    //  from |+1.1234e-123|
+    //  to   |+1.1234-123|
   }
   /*** when the exponent has 2 digits */
   else if( (z < 1.0e-09) || (1.0e+10 <= z && z < 1.0e+100) ){


### PR DESCRIPTION
…ery small cross sections for small energies (<< 1 keV); it is advantageous for checking purposes to have DeCE preserve these small numbers. We employ the <limits> template classes and min() member function; only numbers smaller than 'min_val = numeric_limits<double>::min()' are rewritten to zero.

I've done a sequence of tests to make sure there are no unintended changes and that only entries, v that satisfy 1.e-99 > abs(v) > std::numeric_limits<double>::min() are affected. Further testing is probably not a bad idea.